### PR TITLE
upnp: fix build with miniupnpc 2.2.8

### DIFF
--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -164,7 +164,11 @@ static bool ProcessUpnp()
     struct IGDdatas data;
     int r;
 
+#if MINIUPNPC_API_VERSION <= 17
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#endif
     if (r == 1)
     {
         if (fDiscover) {


### PR DESCRIPTION
Miniupnpc 2.2.8 changed the function signature of UPNP_GetValidIGD without taking much care with the ABI.

This just copies the same fix from Bitcoin Core: https://github.com/bitcoin/bitcoin/pull/30283

